### PR TITLE
Refactor our Qt plugin to make use of the original colors from Qt widget styles

### DIFF
--- a/src/lxqtplatformtheme.cpp
+++ b/src/lxqtplatformtheme.cpp
@@ -43,6 +43,7 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QFileSystemWatcher>
+#include <QStyle>
 #include "qiconloader_p.h"
 
 LXQtPlatformTheme::LXQtPlatformTheme():
@@ -157,7 +158,11 @@ void LXQtPlatformTheme::onSettingsChanged() {
     loadSettings(); // reload the config file
 
     if(style_ != oldStyle) // the widget style is changed
-        qApp->setStyle(style_); // ask Qt5 to apply the new style
+    {
+        // ask Qt5 to apply the new style
+        if (qobject_cast<QApplication *>(QCoreApplication::instance()))
+            QApplication::setStyle(style_);
+    }
 
     if(iconTheme_ != oldIconTheme) { // the icon theme is changed
         QIconLoader::instance()->updateSystemTheme(); // this is a private internal API of Qt5.
@@ -198,12 +203,15 @@ bool LXQtPlatformTheme::usePlatformNativeDialog(DialogType type) const {
 QPlatformDialogHelper *LXQtPlatformTheme::createPlatformDialogHelper(DialogType type) const {
     return 0;
 }
+#endif
 
 const QPalette *LXQtPlatformTheme::palette(Palette type) const {
-    return new QPalette();
-}
 
-#endif
+    if (type == QPlatformTheme::SystemPalette)
+        // the default constructor uses the default palette
+        return new QPalette;
+    return QPlatformTheme::palette(type);
+}
 
 const QFont *LXQtPlatformTheme::font(Font type) const {
 	// qDebug() << "font()" << type << SystemFont;

--- a/src/lxqtplatformtheme.h
+++ b/src/lxqtplatformtheme.h
@@ -48,7 +48,7 @@ public:
     virtual bool usePlatformNativeDialog(DialogType type) const;
     // virtual QPlatformDialogHelper *createPlatformDialogHelper(DialogType type) const;
 
-    // virtual const QPalette *palette(Palette type = SystemPalette) const;
+    virtual const QPalette *palette(Palette type = SystemPalette) const;
 
     virtual const QFont *font(Font type = SystemFont) const;
 


### PR DESCRIPTION
Before:

![before](https://cloud.githubusercontent.com/assets/1238157/8490467/dc968b7c-20ff-11e5-82c4-29dfe4abfef5.jpg)

After:

![after](https://cloud.githubusercontent.com/assets/1238157/8490472/f4a19ba8-20ff-11e5-9cd2-51f909662f36.png)

Looking reeeally nicer now. Credits for [qt5ct](http://sourceforge.net/projects/qt5ct/)'s and [KDE](http://quickgit.kde.org/?p=frameworkintegration.git&a=tree&h=9f7123484e71a5db35d3560aa904fb95f56a40d3&hb=2d53a53c22b1bd392238d76f16e57596c965fc9e&f=src%2Fplatformtheme)'s developers.
Fixes lxde/lxqt#695.