### PR TITLE
SNI: don't create a SNI if support isn't available

### DIFF
--- a/src/lxqtplatformtheme.h
+++ b/src/lxqtplatformtheme.h
@@ -58,7 +58,14 @@ public:
 
     QPlatformSystemTrayIcon *createPlatformSystemTrayIcon() const
     {
-        return new LXQtSystemTrayIcon;
+        auto trayIcon = new LXQtSystemTrayIcon;
+        if (trayIcon->isSystemTrayAvailable())
+            return trayIcon;
+        else
+        {
+            delete trayIcon;
+            return nullptr;
+        }
     }
 
     // virtual QPixmap standardPixmap(StandardPixmap sp, const QSizeF &size) const;


### PR DESCRIPTION
Keep support for the good old `QSystemTrayIcon`. Inspiration from [here](https://bugreports.qt.io/browse/QTBUG-35658?focusedCommentId=272798&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-272798).

Discussion in lxde/lxqt-panel#241.