### PR TITLE
Removed GPL2, added Digia Qt LGPL Exception version 1.1

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,7 +5,6 @@ Upstream Authors:
 Copyright:
     Copyright (c) 2013-2014 LXQt team
 
-License: GPL-2 and LGPL-2.1+
+License: LGPL-2.1+
 The full text of the licenses can be found in the 'COPYING' file.
-
-Based on source code from the Qt 4.8 Project by Digia Plc
+src/qiconloader_p.h is under LGPL-2.1 or 3 with Digia Qt LGPL Exception version 1.1

--- a/Digia-Qt-LGPL-Exception-version-1.1
+++ b/Digia-Qt-LGPL-Exception-version-1.1
@@ -1,0 +1,25 @@
+Digia Qt LGPL Exception version 1.1
+===================================
+
+As an additional permission to the GNU Lesser General Public License version
+2.1, the object code form of a "work that uses the Library" may incorporate
+material from a header file that is part of the Library.  You may distribute
+such object code under terms of your choice, provided that:
+
+    (i)   the header files of the Library have not been modified; and
+    (ii)  the incorporated material is limited to numerical parameters, data
+          structure layouts, accessors, macros, inline functions and
+          templates; and
+    (iii) you comply with the terms of Section 6 of the GNU Lesser General
+          Public License version 2.1.
+
+Moreover, you may apply this exception to a modified version of the Library,
+provided that such modification does not involve copying material from the
+Library into the modified Library's header files unless such material is
+limited to (i) numerical parameters; (ii) data structure layouts;
+(iii) accessors; and (iv) small macros, templates and inline functions of
+five lines or less in length.
+
+Furthermore, you are not required to apply this additional permission to a
+modified version of the Library.
+


### PR DESCRIPTION
there is nothing licensed with GPL2
added Digia-Qt-LGPL-Exception-version-1.1 license file
fixes lxde/lxqt/issues/804