### PR TITLE
Xdg icon theme paths

### DIFF
--- a/src/lxqtplatformtheme.cpp
+++ b/src/lxqtplatformtheme.cpp
@@ -316,7 +316,8 @@ QStringList LXQtPlatformTheme::xdgIconThemePaths() const
     xdgDirs.append(xdgDataDirs);
 
     foreach (const QString &s, xdgDirs) {
-        foreach (const QString &xdgDir, s.split(QLatin1Char(':'))) {
+        const QStringList r = s.split(QLatin1Char(':'), QString::SkipEmptyParts);
+        foreach (const QString &xdgDir, r) {
             const QFileInfo xdgIconsDir(xdgDir + QStringLiteral("/icons"));
             if (xdgIconsDir.isDir())
                 paths.append(xdgIconsDir.absoluteFilePath());

--- a/src/lxqtplatformtheme.cpp
+++ b/src/lxqtplatformtheme.cpp
@@ -298,18 +298,29 @@ QVariant LXQtPlatformTheme::themeHint(ThemeHint hint) const {
 QStringList LXQtPlatformTheme::xdgIconThemePaths() const
 {
     QStringList paths;
+    QStringList xdgDirs;
+
     // Add home directory first in search path
     const QFileInfo homeIconDir(QDir::homePath() + QStringLiteral("/.icons"));
     if (homeIconDir.isDir())
         paths.prepend(homeIconDir.absoluteFilePath());
 
-    QString xdgDirString = QFile::decodeName(qgetenv("XDG_DATA_DIRS"));
-    if (xdgDirString.isEmpty())
-        xdgDirString = QLatin1String("/usr/local/share/:/usr/share/");
-    foreach (const QString &xdgDir, xdgDirString.split(QLatin1Char(':'))) {
-        const QFileInfo xdgIconsDir(xdgDir + QStringLiteral("/icons"));
-        if (xdgIconsDir.isDir())
-            paths.append(xdgIconsDir.absoluteFilePath());
+    QString xdgDataHome = QFile::decodeName(qgetenv("XDG_DATA_HOME"));
+    if (xdgDataHome.isEmpty())
+        xdgDataHome = QDir::homePath() + QLatin1String("/.local/share");
+    xdgDirs.append(xdgDataHome);
+
+    QString xdgDataDirs = QFile::decodeName(qgetenv("XDG_DATA_DIRS"));
+    if (xdgDataDirs.isEmpty())
+        xdgDataDirs = QLatin1String("/usr/local/share/:/usr/share/");
+    xdgDirs.append(xdgDataDirs);
+
+    foreach (const QString &s, xdgDirs) {
+        foreach (const QString &xdgDir, s.split(QLatin1Char(':'))) {
+            const QFileInfo xdgIconsDir(xdgDir + QStringLiteral("/icons"));
+            if (xdgIconsDir.isDir())
+                paths.append(xdgIconsDir.absoluteFilePath());
+        }
     }
     return paths;
 }

--- a/src/lxqtplatformtheme.cpp
+++ b/src/lxqtplatformtheme.cpp
@@ -322,5 +322,6 @@ QStringList LXQtPlatformTheme::xdgIconThemePaths() const
                 paths.append(xdgIconsDir.absoluteFilePath());
         }
     }
+    paths.removeDuplicates();
     return paths;
 }


### PR DESCRIPTION
This half of the solution of https://github.com/lxde/lxqt/issues/1010
After it gets in, we can stop adding `XDG_DATA_HOME` to `XDG_DATA_DIRS` in lxqt-common.