### PR TITLE
build: Add option for StatusNotifierItem usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,23 @@ set(CMAKE_AUTOMOC ON)
 
 find_package(Qt5Widgets REQUIRED QUIET)
 find_package(Qt5LinguistTools REQUIRED QUIET)
-find_package(Qt5DBus REQUIRED QUIET)
-find_package(dbusmenu-qt5 REQUIRED QUIET)
+
+#Build with our StatusNotifierItem implementation?
+#if not defined by user, decide by Qt version
+if (NOT DEFINED WITH_SNI)
+    if (Qt5Widgets_VERSION VERSION_LESS 5.6.1)
+        set(WITH_SNI ON)
+    else ()
+        set(WITH_SNI OFF)
+    endif ()
+endif ()
+if (WITH_SNI)
+    message(STATUS "Building with our StatusNotifierItem implementation")
+    find_package(Qt5DBus REQUIRED QUIET)
+    find_package(dbusmenu-qt5 REQUIRED QUIET)
+else ()
+    message(STATUS "Building w/o our StatusNotifierItem implementation")
+endif ()
 
 find_package(lxqt REQUIRED QUIET)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,34 +5,50 @@ include_directories(
 
 set(qtlxqt_HDRS
     lxqtplatformtheme.h
-    lxqtsystemtrayicon.h
-    statusnotifieritem/statusnotifieritem.h
-    statusnotifieritem/dbustypes.h
 )
 
 set(qtlxqt_SRCS
     main.cpp
     lxqtplatformtheme.cpp
-    lxqtsystemtrayicon.cpp
-    statusnotifieritem/statusnotifieritem.cpp
-    statusnotifieritem/dbustypes.cpp
 )
 
-qt5_add_dbus_adaptor(qtlxqt_SRCS
-    statusnotifieritem/org.kde.StatusNotifierItem.xml
-    statusnotifieritem/statusnotifieritem.h
-    StatusNotifierItem
-)
+if (WITH_SNI)
+    list(APPEND qtlxqt_HDRS
+        lxqtsystemtrayicon.h
+        statusnotifieritem/statusnotifieritem.h
+        statusnotifieritem/dbustypes.h
+    )
+
+    list(APPEND qtlxqt_SRCS
+        lxqtsystemtrayicon.cpp
+        statusnotifieritem/statusnotifieritem.cpp
+        statusnotifieritem/dbustypes.cpp
+    )
+
+    qt5_add_dbus_adaptor(qtlxqt_SRCS
+        statusnotifieritem/org.kde.StatusNotifierItem.xml
+        statusnotifieritem/statusnotifieritem.h
+        StatusNotifierItem
+    )
+
+    add_definitions(-DWITH_SNI)
+endif ()
+
 
 add_library(qtlxqt SHARED ${qtlxqt_HDRS} ${qtlxqt_SRCS})
 
 target_link_libraries(qtlxqt
     Qt5::Widgets
-    Qt5::DBus
-    dbusmenu-qt5
     lxqt
     Qt5XdgIconLoader
 )
+
+if (WITH_SNI)
+    target_link_libraries(qtlxqt
+        Qt5::DBus
+        dbusmenu-qt5
+    )
+endif ()
 
 # there is no standard way to get the plugin dir of Qt5 with cmake
 # The best way is get_target_property(QT_PLUGINS_DIR Qt5::QGtk2ThemePlugin LOCATION).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,12 @@
+#XXX: a hack for including private QtPlatformTheme headers (it is not exported in any *.cmake file)
+foreach (dir ${Qt5Core_PRIVATE_INCLUDE_DIRS})
+    string(REPLACE "QtCore" "QtPlatformSupport" replaced_dir "${dir}")
+    list(APPEND QtPlatformSupport_PRIVATE_INCLUDE_DIRS "${replaced_dir}")
+endforeach ()
+
 include_directories(
     ${Qt5Gui_PRIVATE_INCLUDE_DIRS}
+    ${QtPlatformSupport_PRIVATE_INCLUDE_DIRS}
     "${CMAKE_CURRENT_BINARY_DIR}"
 )
 
@@ -41,6 +48,7 @@ target_link_libraries(qtlxqt
     Qt5::Widgets
     lxqt
     Qt5XdgIconLoader
+    Qt5PlatformSupport
 )
 
 if (WITH_SNI)

--- a/src/lxqtplatformtheme.h
+++ b/src/lxqtplatformtheme.h
@@ -28,7 +28,9 @@
 #ifndef LXQTPLATFORMTHEME_H
 #define LXQTPLATFORMTHEME_H
 
+#if defined(WITH_SNI)
 #include "lxqtsystemtrayicon.h"
+#endif
 
 #include <qpa/qplatformtheme.h> // this private header is subject to changes
 #include <QtGlobal>
@@ -56,6 +58,7 @@ public:
 
     virtual QVariant themeHint(ThemeHint hint) const;
 
+#if defined(WITH_SNI)
     QPlatformSystemTrayIcon *createPlatformSystemTrayIcon() const
     {
         auto trayIcon = new LXQtSystemTrayIcon;
@@ -67,6 +70,7 @@ public:
             return nullptr;
         }
     }
+#endif
 
     // virtual QPixmap standardPixmap(StandardPixmap sp, const QSizeF &size) const;
     // virtual QPixmap fileIconPixmap(const QFileInfo &fileInfo, const QSizeF &size,

--- a/src/lxqtplatformtheme.h
+++ b/src/lxqtplatformtheme.h
@@ -32,14 +32,14 @@
 #include "lxqtsystemtrayicon.h"
 #endif
 
-#include <qpa/qplatformtheme.h> // this private header is subject to changes
+#include <QtPlatformSupport/private/qgenericunixthemes_p.h> // this private header is subject to changes
 #include <QtGlobal>
 #include <QVariant>
 #include <QString>
 #include <QFileSystemWatcher>
 #include <QFont>
 
-class Q_GUI_EXPORT LXQtPlatformTheme : public QObject, public QPlatformTheme {
+class Q_GUI_EXPORT LXQtPlatformTheme : public QObject, public QGenericUnixTheme {
     Q_OBJECT
 public:
     LXQtPlatformTheme();


### PR DESCRIPTION
Use our StatusNotifierItem implementation only when forced by build system (packager) or if Qt < v5.6.1

fixes lxde/lxqt#1082