### PR TITLE
Use the new lxqt-build-tools package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,25 @@
 cmake_minimum_required(VERSION 3.0.2 FATAL_ERROR)
 project(lxqt-qtplugin)
 
+include(GNUInstallDirs)
+
 set(LXQTBT_MINIMUM_VERSION "0.1.0")
 
+set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-set(CMAKE_AUTOMOC ON)
 
 find_package(Qt5Widgets REQUIRED QUIET)
 find_package(Qt5LinguistTools REQUIRED QUIET)
 find_package(Qt5DBus REQUIRED QUIET)
 find_package(dbusmenu-qt5 REQUIRED QUIET)
-
 find_package(lxqt-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt5XdgIconLoader REQUIRED QUIET)
 
 include(LXQtCompilerSettings NO_POLICY_SCOPE)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
 
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.0.2 FATAL_ERROR)
 project(lxqt-qtplugin)
 
+set(LXQTBT_MINIMUM_VERSION "0.1.0")
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_AUTOMOC ON)
@@ -10,7 +12,7 @@ find_package(Qt5LinguistTools REQUIRED QUIET)
 find_package(Qt5DBus REQUIRED QUIET)
 find_package(dbusmenu-qt5 REQUIRED QUIET)
 
-find_package(lxqt REQUIRED QUIET)
+find_package(lxqt-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt5XdgIconLoader REQUIRED QUIET)
 
 include(LXQtCompilerSettings NO_POLICY_SCOPE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,6 @@ target_link_libraries(qtlxqt
     Qt5::Widgets
     Qt5::DBus
     dbusmenu-qt5
-    lxqt
     Qt5XdgIconLoader
 )
 


### PR DESCRIPTION
Drop liblxqt build and runtime dependency. It's actually not needed.