### PR TITLE
Update the icon theme name cached inside QIconLoader properly.

### DIFF
--- a/src/lxqtplatformtheme.cpp
+++ b/src/lxqtplatformtheme.cpp
@@ -44,7 +44,9 @@
 #include <QFileInfo>
 #include <QFileSystemWatcher>
 #include <QStyle>
+
 #include <private/xdgiconloader/xdgiconloader_p.h>
+
 
 LXQtPlatformTheme::LXQtPlatformTheme():
     settingsWatcher_(NULL)
@@ -122,6 +124,9 @@ void LXQtPlatformTheme::loadSettings() {
     settings.endGroup();
 }
 
+// defined in main.cpp
+void updateQIconLoader();
+
 // this is called whenever the config file is changed.
 void LXQtPlatformTheme::onSettingsChanged() {
     // D*mn! yet another Qt 5.4 regression!!!
@@ -162,7 +167,9 @@ void LXQtPlatformTheme::onSettingsChanged() {
     }
 
     if(iconTheme_ != oldIconTheme) { // the icon theme is changed
-        XdgIconLoader::instance()->updateSystemTheme(); // this is a private internal API of Qt5.
+        // ask QIconLoader and XdgIconLoader to update the cached icon theme name.
+        updateQIconLoader();
+        XdgIconLoader::instance()->updateSystemTheme();
     }
 
     // if font is changed

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,8 @@
 #include <qpa/qplatformthemeplugin.h>
 #include "lxqtplatformtheme.h"
 
+#include <QtGui/private/qiconloader_p.h>
+
 QT_BEGIN_NAMESPACE
 
 class LXQtPlatformThemePlugin: public QPlatformThemePlugin {
@@ -43,6 +45,14 @@ QPlatformTheme *LXQtPlatformThemePlugin::create(const QString &key, const QStrin
     if (!key.compare(QLatin1String("lxqt"), Qt::CaseInsensitive))
         return new LXQtPlatformTheme();
     return NULL;
+}
+
+// We cannot call QIconLoader in lxqtplatformtheme.cpp because XdgIconLoader contains the same
+// class name so including both of qiconloader_p.h and XdgIconLoader create a name clash.
+// Let's call QIconLoader::updateSystemTheme() here instead.
+void updateQIconLoader() {
+  // this is a private internal API of Qt5.
+  QIconLoader::instance()->updateSystemTheme();
 }
 
 QT_END_NAMESPACE


### PR DESCRIPTION
The change made in 78735d5c38d2a1db221e1b3a71ec6c69ccf544e9 replaced QIconLoader with XdgIconLoader, but the original QIconLoader::instance()->updateSystemTheme() should not be deleted.
Internally XdgIconLoader and the Qt5 built-in QIconLoader have separate icon theme name settings. So when the icon theme name is changed, you have to notify both.
Without the fix, after you change the icon theme, QIcon::themeName() always returns the old icon theme.
@luis-pereira Please help review the PR.
Thank you.