### PR TITLE
Fix multiple StatusNotifierItems.

### DIFF
--- a/src/statusnotifieritem/statusnotifieritem.h
+++ b/src/statusnotifieritem/statusnotifieritem.h
@@ -32,6 +32,7 @@
 #include <QObject>
 #include <QIcon>
 #include <QMenu>
+#include <QDBusConnection>
 
 #include "dbustypes.h"
 
@@ -176,6 +177,7 @@ private:
     QMenu *mMenu;
     QDBusObjectPath mMenuPath;
     DBusMenuExporter *mMenuExporter;
+    QDBusConnection mSessionBus;
 
     static int mServiceCounter;
 };


### PR DESCRIPTION
StatusNotifierItems were cloned, because only one object was registered
for all StatusNotifierItem services.

Adding support for multiple notifiers fixes https://github.com/lxde/lxqt/issues/1105 for me.