### PR TITLE
LXQtPlatformTheme: Do not provide own palette

### DIFF
--- a/src/lxqtplatformtheme.cpp
+++ b/src/lxqtplatformtheme.cpp
@@ -202,14 +202,6 @@ QPlatformDialogHelper *LXQtPlatformTheme::createPlatformDialogHelper(DialogType 
 }
 #endif
 
-const QPalette *LXQtPlatformTheme::palette(Palette type) const {
-
-    if (type == QPlatformTheme::SystemPalette)
-        // the default constructor uses the default palette
-        return new QPalette;
-    return QPlatformTheme::palette(type);
-}
-
 const QFont *LXQtPlatformTheme::font(Font type) const {
     if(type == SystemFont && !fontStr_.isEmpty()) {
         // NOTE: for some reason, this is not called by Qt when program startup.

--- a/src/lxqtplatformtheme.h
+++ b/src/lxqtplatformtheme.h
@@ -50,7 +50,7 @@ public:
     virtual bool usePlatformNativeDialog(DialogType type) const;
     // virtual QPlatformDialogHelper *createPlatformDialogHelper(DialogType type) const;
 
-    virtual const QPalette *palette(Palette type = SystemPalette) const;
+    // virtual const QPalette *palette(Palette type = SystemPalette) const;
 
     virtual const QFont *font(Font type = SystemFont) const;
 


### PR DESCRIPTION
1. avoid leak by creating new object
2. we don't support overriding of colors -> default Qt palette is OK