### PR TITLE
Prevent a possible C++11 range for detach

### DIFF
--- a/src/statusnotifieritem/statusnotifieritem.cpp
+++ b/src/statusnotifieritem/statusnotifieritem.cpp
@@ -287,7 +287,8 @@ IconPixmapList StatusNotifierItem::iconToPixmapList(const QIcon& icon)
     IconPixmapList pixmapList;
 
     // long live KDE!
-    for (const QSize &size : icon.availableSizes())
+    const QList<QSize> sizes = icon.availableSizes();
+    for (const QSize &size : sizes)
     {
         QImage image = icon.pixmap(size).toImage();
 


### PR DESCRIPTION
The solution with Qt>=5.7 is to use the qAsConst() macro.
But the qAsConst macro is just a const_cast to const T&.