### PR TITLE
LXQtPlatformTheme: Make Qt use default palette

### DIFF
--- a/src/lxqtplatformtheme.cpp
+++ b/src/lxqtplatformtheme.cpp
@@ -207,6 +207,10 @@ QPlatformDialogHelper *LXQtPlatformTheme::createPlatformDialogHelper(DialogType 
 }
 #endif
 
+const QPalette *LXQtPlatformTheme::palette(Palette type) const {
+    return nullptr;
+}
+
 const QFont *LXQtPlatformTheme::font(Font type) const {
     if(type == SystemFont && !fontStr_.isEmpty()) {
         // NOTE: for some reason, this is not called by Qt when program startup.

--- a/src/lxqtplatformtheme.h
+++ b/src/lxqtplatformtheme.h
@@ -50,7 +50,7 @@ public:
     virtual bool usePlatformNativeDialog(DialogType type) const;
     // virtual QPlatformDialogHelper *createPlatformDialogHelper(DialogType type) const;
 
-    // virtual const QPalette *palette(Palette type = SystemPalette) const;
+    virtual const QPalette *palette(Palette type = SystemPalette) const;
 
     virtual const QFont *font(Font type = SystemFont) const;
 


### PR DESCRIPTION
Fixes forcing the Fusion palette even if other style engine used (as
the QPlatformTheme::palette() does force the fusion).

The mentioned regression was introduced by d5f8558ee6ad.

fixes lxde/lxqt#1312