### PR TITLE
Handle the new hint ShowShortcutsInContextMenus

### DIFF
--- a/src/lxqtplatformtheme.cpp
+++ b/src/lxqtplatformtheme.cpp
@@ -302,7 +302,10 @@ QVariant LXQtPlatformTheme::themeHint(ThemeHint hint) const {
         break;
     case WheelScrollLines:
         return wheelScrollLines_;
-        break;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+    case QPlatformTheme::ShowShortcutsInContextMenus:
+        return QVariant(true);
+#endif
     default:
         break;
     }


### PR DESCRIPTION
Fixes https://github.com/lxde/lxqt/issues/1426.

ShowShortcutsInContextMenus is false by default and, contrary to it name, it isn't just about context menus.